### PR TITLE
Fix for the ReDOS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "commander": "^2.8.1",
     "cross-spawn": "^0.4.1",
     "csscomb": "^3.1.8",
-    "eslint": "^0.24.0",
+    "eslint": "^1.9.0",
     "eslint-plugin-react": "^2.6.3",
     "fs-extra": "^0.29.0",
     "glob": "^5.0.10",


### PR DESCRIPTION
check-style is currently affected by the high-severity [ReDOS vulnerability](https://snyk.io/vuln/npm:minimatch:20160620). 

Vulnerable module: `minimatch`
Introduced through: `eslint`

This PR fixes the ReDoS vulnerability by upgrading `eslint` to version 1.9.0.

Check out the [Snyk test report](https://snyk.io/test/github/qiu8310/check-style) to review other vulnerabilities that affect this repo. 

[Watch the repo](https://snyk.io/add) to 
- get alerts if newly disclosed vulnerabilities affect this repo in the future. 
- generate pull requests with the fixes you want, or let us do the work: when a newly disclosed vulnerability affects you, we'll submit a fix to you right away. 

Stay secure, 
The Snyk team
